### PR TITLE
Added the possibility to hide the route button

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ class PlayerVolume extends React.Component {
           thumbTintColor="rgb(146,146,157)"
           minimumTrackTintColor="rgb(146,146,157)"
           maximumTrackTintColor="rgba(255,255,255, 0.1)"
+          showsRouteButton={true}
           onValueChange={this.volumeChange.bind(this)} />
       </View>
     );
@@ -83,3 +84,6 @@ The color used for the thumb.
 
 ##### `thumbImage`
 Specify an image here to use as thumb. This will be drawn to the round
+
+##### `showsRouteButton`
+Indicates whether or not to show the `routeButton` where the user can select the output target (airplay, headphones)

--- a/VolumeSlider.js
+++ b/VolumeSlider.js
@@ -45,6 +45,11 @@ class VolumeSlider extends Component {
     maximumTrackTintColor: PropTypes.string,
 
     /**
+     * Specifies whether or not to show the route button for airplay
+     */
+    showsRouteButton: PropTypes.bool,
+
+    /**
      * Callback continuously called while the user is dragging the slider.
      */
     onValueChange: PropTypes.func
@@ -52,6 +57,7 @@ class VolumeSlider extends Component {
 
   static defaultProps = {
     thumbSize: { width: 23, height: 23 },
+    showsRouteButton: true
   };
 
   render() {

--- a/ios/RNVolumeSlider/VolumeSliderManager.m
+++ b/ios/RNVolumeSlider/VolumeSliderManager.m
@@ -13,6 +13,7 @@ RCT_EXPORT_VIEW_PROPERTY(maximumTrackTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(thumbTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(onValueChange, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(thumbImage, UIImage);
+RCT_EXPORT_VIEW_PROPERTY(showsRouteButton, BOOL);
 RCT_CUSTOM_VIEW_PROPERTY(thumbSize, RCTthumbSize, VolumeSlider) {
   NSDictionary *thumbSize = (NSDictionary *) json;
   


### PR DESCRIPTION
MPVolumeSlider can hide the so called `routeButton` which is useful for
airplay or the output through headphones. Sometimes it just is not
necessary.
