### PR TITLE
Use absolute path to import RCTComponent

### DIFF
--- a/ios/RNVolumeSlider/VolumeSlider.h
+++ b/ios/RNVolumeSlider/VolumeSlider.h
@@ -1,5 +1,5 @@
 #import <UIKit/UIKit.h>
-#import "RCTComponent.h"
+#import <React/RCTComponent.h>
 @import MediaPlayer;
 
 typedef struct {


### PR DESCRIPTION
https://github.com/facebook/react-native/releases/tag/v0.40.0

After [e1577df](https://github.com/facebook/react-native/commit/e1577df1fd70049ce7f288f91f6e2b18d512ff4d), Native code on iOS must refer to headers out of the react namespace.

Previously the following would work:

```c-sharp
#import "RCTUtils.h"
```

But now all headers have been moved:

```c-sharp
#import <React/RCTUtils.h>
```