### PR TITLE
fix prop-types import

### DIFF
--- a/VolumeSlider.js
+++ b/VolumeSlider.js
@@ -6,7 +6,8 @@ import {
   StyleSheet,
   Image
 } from 'react-native';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types'
 
 type Event = Object;
 

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/IFours/react-native-volume-slider/issues"
   },
-  "homepage": "https://github.com/IFours/react-native-volume-slider#readme"
+  "homepage": "https://github.com/IFours/react-native-volume-slider#readme",
+  "dependencies": {
+    "prop-types": "15.6.0"
+  }
 }


### PR DESCRIPTION
The PropTypes package was separated from React into `prop-types`.